### PR TITLE
Add extra classes to pagination tag

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -13,6 +13,11 @@ Render Pagination with a theme
 
     = paginate @posts, :theme => 'twitter-bootstrap'
 
+Render with specific pagination classes
+
+    = paginate @posts, :theme => 'twitter-bootstrap', 
+                       :pagination_class => "pagination-small pagination-centered"
+
 = Credits
 
 {Kaminari}[https://github.com/amatsuda/kaminari] - For making an awesome gem

--- a/app/views/kaminari/twitter-bootstrap/_paginator.html.erb
+++ b/app/views/kaminari/twitter-bootstrap/_paginator.html.erb
@@ -6,8 +6,10 @@
     remote:        data-remote
     paginator:     the paginator that renders the pagination tags inside
 -%>
+<% pagination_class ||= "" %>
+
 <%= paginator.render do -%>
-  <div class="pagination">
+  <div class="pagination <%= pagination_class %>">
     <ul>
     <%= first_page_tag unless current_page.first? %>
     <%= prev_page_tag unless current_page.first? %>

--- a/lib/bootstrap-kaminari-views/version.rb
+++ b/lib/bootstrap-kaminari-views/version.rb
@@ -1,3 +1,3 @@
 module BootstrapKaminariViews
-  VERSION = "0.0.2"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
I just developed a little bit more your gem in order to be able to pass parameters to the pagination tag.

I needed it to center the paginator in my project.

Feel free to incorporate this commit in your gem. In fact, I'd would be very happy if you include it in your gem so I won't need to install the gem through github but rubygems. It is always cleaner :)

In any case, thanks a lot for your gem. It have been really useful :)
