### PR TITLE
Support for Pagination with Twitter Bootstrap 3

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = Bootstrap Kaminari Views
 
-Basic Gem for quick default inclusion of {Kaminari}[https://github.com/amatsuda/kaminari] theme compatible with {Twitter Bootstrap 2.0}[http://twitter.github.com/bootstrap]
+Basic Gem for quick default inclusion of {Kaminari}[https://github.com/amatsuda/kaminari] theme compatible with {Twitter Bootstrap 2.0}[http://getbootstrap.com/2.3.2/] and {Twitter Bootstrap 3.0}[http://getbootstrap.com]
 
 = Usage
 
@@ -12,6 +12,13 @@ Ensure your gemfile contains
 Render Pagination with a theme
 
     = paginate @posts, :theme => 'twitter-bootstrap'
+    
+    = paginate @posts, :theme => 'twitter-bootstrap-3'
+
+Render with specific pagination classes
+
+    = paginate @posts, :theme => 'twitter-bootstrap-3', 
+                       :pagination_class => "pagination-sm"
 
 Render with specific pagination classes
 

--- a/app/views/kaminari/twitter-bootstrap-3/_first_page.html.erb
+++ b/app/views/kaminari/twitter-bootstrap-3/_first_page.html.erb
@@ -1,0 +1,13 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% unless current_page.first? %>
+<li class="first">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote %>
+</li>
+<% end %>

--- a/app/views/kaminari/twitter-bootstrap-3/_gap.html.erb
+++ b/app/views/kaminari/twitter-bootstrap-3/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="page gap disabled"><a href="#" onclick="return false;"><%= raw(t 'views.pagination.truncate') %></a></li>

--- a/app/views/kaminari/twitter-bootstrap-3/_last_page.html.erb
+++ b/app/views/kaminari/twitter-bootstrap-3/_last_page.html.erb
@@ -1,0 +1,13 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% unless current_page.last? %>
+<li class="last next"><%# "next" class present for border styling in twitter bootstrap %>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote} %>
+</li>
+<% end %>

--- a/app/views/kaminari/twitter-bootstrap-3/_next_page.html.erb
+++ b/app/views/kaminari/twitter-bootstrap-3/_next_page.html.erb
@@ -1,0 +1,13 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% unless current_page.last? %>
+<li class="next_page">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote %>
+</li>
+<% end %>

--- a/app/views/kaminari/twitter-bootstrap-3/_page.html.erb
+++ b/app/views/kaminari/twitter-bootstrap-3/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="page<%= ' active' if page.current? %>">
+  <%= link_to page, url, opts = {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+</li>

--- a/app/views/kaminari/twitter-bootstrap-3/_paginator.html.erb
+++ b/app/views/kaminari/twitter-bootstrap-3/_paginator.html.erb
@@ -1,0 +1,23 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+<ul class="pagination">
+  <%= first_page_tag unless current_page.first? %>
+  <%= prev_page_tag unless current_page.first? %>
+  <% each_page do |page| -%>
+    <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+      <%= page_tag page %>
+    <% elsif !page.was_truncated? -%>
+      <%= gap_tag %>
+    <% end -%>
+  <% end -%>
+  <%= next_page_tag unless current_page.last? %>
+  <%= last_page_tag unless current_page.last? %>
+</ul>
+<% end -%>

--- a/app/views/kaminari/twitter-bootstrap-3/_prev_page.html.erb
+++ b/app/views/kaminari/twitter-bootstrap-3/_prev_page.html.erb
@@ -1,0 +1,13 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% unless current_page.first? %>
+<li class="prev">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote %>
+</li>
+<% end %>

--- a/bootstrap-kaminari-views.gemspec
+++ b/bootstrap-kaminari-views.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email       = ["matenia@gmail.com"]
   s.homepage    = "http://github.com/matenia/bootstrap-kaminari-views"
   s.summary     = "Bootstrap-ify pagination with Kaminari"
-  s.description = "Bootstrap-ify pagination with Kaminari - Compatible with Bootstrap 2.x"
+  s.description = "Bootstrap-ify pagination with Kaminari - Compatible with Bootstrap 2.x, 3.x"
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
 

--- a/lib/bootstrap-kaminari-views/version.rb
+++ b/lib/bootstrap-kaminari-views/version.rb
@@ -1,3 +1,3 @@
 module BootstrapKaminariViews
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
I've implemented support for a twitter-bootstrap-3 paginator, separate from twitter-bootstrap (2).

You may wish to just leave 2 behind and go with 3 as the default - but I was in a situation where I needed legacy support for twitter-bootstrap while also using the twitter-bootstrap-3 on some newer sections of the code.
