### PR TITLE
Add centered option

### DIFF
--- a/app/views/kaminari/twitter-bootstrap-3/_paginator.html.erb
+++ b/app/views/kaminari/twitter-bootstrap-3/_paginator.html.erb
@@ -8,17 +8,19 @@
 -%>
 <%- pagination_class ||= '' %>
 <%= paginator.render do -%>
-<ul class="pagination <%= pagination_class %>">
-  <%= first_page_tag unless current_page.first? %>
-  <%= prev_page_tag unless current_page.first? %>
-  <% each_page do |page| -%>
-    <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
-      <%= page_tag page %>
-    <% elsif !page.was_truncated? -%>
-      <%= gap_tag %>
+<nav>
+  <ul class="pagination <%= pagination_class %>">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
     <% end -%>
-  <% end -%>
-  <%= next_page_tag unless current_page.last? %>
-  <%= last_page_tag unless current_page.last? %>
-</ul>
+    <%= next_page_tag unless current_page.last? %>
+    <%= last_page_tag unless current_page.last? %>
+  </ul>
+</nav>
 <% end -%>

--- a/app/views/kaminari/twitter-bootstrap-3/_paginator.html.erb
+++ b/app/views/kaminari/twitter-bootstrap-3/_paginator.html.erb
@@ -25,5 +25,5 @@
       <%= last_page_tag unless current_page.last? %>
     </ul>
   </nav>
-<% if centered %> <div> <!-- text-center --> <% end %>
+<% if centered %> </div> <!-- text-center --> <% end %>
 <% end -%>

--- a/app/views/kaminari/twitter-bootstrap-3/_paginator.html.erb
+++ b/app/views/kaminari/twitter-bootstrap-3/_paginator.html.erb
@@ -9,25 +9,21 @@
 <%- pagination_class ||= '' %>
 <%- centered ||= pagination_class.split(" ").include?("pagination-centered") %>
 <%= paginator.render do -%>
-<nav>
-  <% if centered %>
-    <div class="text-center">
-  <% end %>
-      <ul class="pagination <%= pagination_class %>">
-        <%= first_page_tag unless current_page.first? %>
-        <%= prev_page_tag unless current_page.first? %>
-        <% each_page do |page| -%>
-          <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
-            <%= page_tag page %>
-          <% elsif !page.was_truncated? -%>
-            <%= gap_tag %>
-          <% end -%>
+<% if centered %> <div class="text-center"> <% end %>
+  <nav>
+    <ul class="pagination <%= pagination_class %>">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| -%>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
         <% end -%>
-        <%= next_page_tag unless current_page.last? %>
-        <%= last_page_tag unless current_page.last? %>
-      </ul>
-  <% if centered %>
-    <div> <!-- text-center -->
-  <% end %>
-</nav>
+      <% end -%>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% if centered %> <div> <!-- text-center --> <% end %>
 <% end -%>

--- a/app/views/kaminari/twitter-bootstrap-3/_paginator.html.erb
+++ b/app/views/kaminari/twitter-bootstrap-3/_paginator.html.erb
@@ -7,20 +7,27 @@
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%- pagination_class ||= '' %>
+<%- centered ||= pagination_class.split(" ").include?("pagination-centered") %>
 <%= paginator.render do -%>
 <nav>
-  <ul class="pagination <%= pagination_class %>">
-    <%= first_page_tag unless current_page.first? %>
-    <%= prev_page_tag unless current_page.first? %>
-    <% each_page do |page| -%>
-      <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
-        <%= page_tag page %>
-      <% elsif !page.was_truncated? -%>
-        <%= gap_tag %>
-      <% end -%>
-    <% end -%>
-    <%= next_page_tag unless current_page.last? %>
-    <%= last_page_tag unless current_page.last? %>
-  </ul>
+  <% if centered %>
+    <div class="text-center">
+  <% end %>
+      <ul class="pagination <%= pagination_class %>">
+        <%= first_page_tag unless current_page.first? %>
+        <%= prev_page_tag unless current_page.first? %>
+        <% each_page do |page| -%>
+          <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+            <%= page_tag page %>
+          <% elsif !page.was_truncated? -%>
+            <%= gap_tag %>
+          <% end -%>
+        <% end -%>
+        <%= next_page_tag unless current_page.last? %>
+        <%= last_page_tag unless current_page.last? %>
+      </ul>
+  <% if centered %>
+    <div> <!-- text-center -->
+  <% end %>
 </nav>
 <% end -%>


### PR DESCRIPTION
Users can use `centered: true` or the deprecated class `pagination_class: 'pagination-centered'` to center their pagination.
